### PR TITLE
Added .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf
+
+[test.txt]
+insert_final_newline = false


### PR DESCRIPTION
Note that the `test.txt` entry is to ensure that a newline character isn't added to the end of the testing file, which could cause the test to fail.

---

Closes #60 